### PR TITLE
feat(vat): implement FormReadyComponent for missing VAT notification

### DIFF
--- a/apps/web/src/app/[lang]/(main)/(unirefund)/settings/product/product-groups/new/page.tsx
+++ b/apps/web/src/app/[lang]/(main)/(unirefund)/settings/product/product-groups/new/page.tsx
@@ -1,5 +1,9 @@
 "use server";
 
+import { FormReadyComponent } from "@repo/ui/form-ready";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { FileText } from "lucide-react";
 import { getVatsApi } from "src/actions/unirefund/SettingService/actions";
 import { getResourceData } from "src/language-data/unirefund/SettingService";
 import { isUnauthorized } from "src/utils/page-policy/page-policy";
@@ -19,10 +23,24 @@ export default async function Page({ params }: { params: { lang: string } }) {
   const { languageData } = await getResourceData(lang);
   return (
     <>
-      <Form
-        languageData={languageData}
-        vatList={vatsResponse.data.items || []}
-      />
+      <FormReadyComponent
+        active={vatsResponse.data.items?.length === 0}
+        content={{
+          icon: <FileText className="size-20 text-gray-400" />,
+          title: languageData["Missing.Vat.Title"],
+          message: languageData["Missing.Vat.Message"],
+          action: (
+            <Button asChild className="text-blue-500" variant="link">
+              <Link href="../vats/new">{languageData["Vat.New"]}</Link>
+            </Button>
+          ),
+        }}
+      >
+        <Form
+          languageData={languageData}
+          vatList={vatsResponse.data.items || []}
+        />
+      </FormReadyComponent>
       <div className="hidden" id="page-description">
         {languageData["ProductGroups.Create.Description"]}
       </div>

--- a/apps/web/src/language-data/unirefund/SettingService/resources/en.json
+++ b/apps/web/src/language-data/unirefund/SettingService/resources/en.json
@@ -1,4 +1,7 @@
 {
+  "Missing.Vat.Title": "Missing VAT",
+  "Missing.Vat.Message": "There is no vat in the system. Please create one to continue.",
+
   "Vat": "VAT",
   "ProductGroup": "Product Group",
   "Vat.New": "New VAT",

--- a/apps/web/src/language-data/unirefund/SettingService/resources/tr.json
+++ b/apps/web/src/language-data/unirefund/SettingService/resources/tr.json
@@ -1,4 +1,7 @@
 {
+  "Missing.Vat.Title": "Eksik VAT",
+  "Missing.Vat.Message": "Sistemde VAT bulunmamaktadır. Devam etmek için lütfen bir tane oluşturun.",
+
   "Vat": "VAT",
   "ProductGroup": "Ürün Grubu",
   "Vat.New": "Yeni VAT",

--- a/packages/ui/src/form-ready/index.tsx
+++ b/packages/ui/src/form-ready/index.tsx
@@ -16,7 +16,7 @@ export function FormReadyComponent({
   return (
     <div className="relative size-full">
       <div className="pointer-events-none">{children}</div>
-      <div className="absolute inset-0 z-20">
+      <div className="absolute inset-0 z-[999]">
         <div className="flex size-full flex-col items-center justify-center gap-4 px-4 py-8 text-center lg:px-12 lg:py-16">
           {content.icon}
           <h1 className="text-2xl font-bold leading-none tracking-tight text-gray-900 md:text-3xl xl:text-4xl">
@@ -28,7 +28,7 @@ export function FormReadyComponent({
           {content.action}
         </div>
       </div>
-      <div className="absolute inset-0 bg-white opacity-90"></div>
+      <div className="absolute inset-0 z-[998] bg-white opacity-90"></div>
     </div>
   );
 }


### PR DESCRIPTION
closes [#1096](https://github.com/ayasofyazilim-clomerce/ayasofyazilim-core-project/issues/1096)

## Description
<!--- Describe your changes in detail -->
![resim](https://github.com/user-attachments/assets/65fb071a-164d-4820-9694-9efb706c7b6a)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Prod
- [ ] Development

### Testing Screenshots:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Added all translations, no hard coded text. 
- [ ] Updated the UI (if needed).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
